### PR TITLE
v0.0.7 - main.py: 저장 파일명 날짜를 연도(4자리)만 사용하도록 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,8 +105,10 @@ def save_single_file(args):
     stat_tbl_id = stats_src['stat_tbl_id']
     src_data_id = data_info.get('src_data_id', 'unknown')
     stat_title = data_info.get('stat_title', 'unknown')
-    from_str = data_info.get('collect_start_dt', 'unknown')
-    to_str = data_info.get('collect_end_dt', 'unknown')
+    _start = data_info.get('collect_start_dt', 'unknown')
+    _end = data_info.get('collect_end_dt', 'unknown')
+    from_str = str(_start)[:4] if str(_start) not in ('unknown', '', 'None') else 'unknown'
+    to_str = str(_end)[:4] if str(_end) not in ('unknown', '', 'None') else 'unknown'
     meta_format = 'xml'
     func_name = 'save_single_file'
     try:


### PR DESCRIPTION
## 변경 내용
- `main.py` `save_single_file()`: `collect_start_dt`/`collect_end_dt` 전체 날짜 문자열 대신 앞 4자리(연도)만 파일명에 사용
- README 파일명 예시(`{from_year}-{to_year}`) 및 KOSIS API URL 파라미터와 일관성 확보

Closes #19