### PR TITLE
v0.0.12 - db.py: DB_URL 미설정 시 엔진 지연 생성 처리 + insert_data_to_db stub 제거

### DIFF
--- a/db.py
+++ b/db.py
@@ -8,8 +8,8 @@ from config import get_db_url, get_kosis_sys
 load_dotenv()
 
 DB_URL = get_db_url()
-engine = create_engine(DB_URL)
-Session = sessionmaker(bind=engine)
+engine = create_engine(DB_URL) if DB_URL else None
+Session = sessionmaker(bind=engine) if engine else None
 
 db_logger = logging.getLogger('db')
 
@@ -21,11 +21,12 @@ def set_timezone(dbapi_connection, connection_record):
     cursor.close()
 
 # 엔진에 이벤트 리스너 등록
-try:
-    event.listen(engine, 'connect', set_timezone)
-    db_logger.info("DB 세션 타임존을 Asia/Seoul로 설정했습니다.")
-except Exception as e:
-    db_logger.error(f"DB 타임존 설정 실패: {e}")
+if engine:
+    try:
+        event.listen(engine, 'connect', set_timezone)
+        db_logger.info("DB 세션 타임존을 Asia/Seoul로 설정했습니다.")
+    except Exception as e:
+        db_logger.error(f"DB 타임존 설정 실패: {e}")
 
 def get_api_info():
     db_logger.info("KOSIS API 정보 조회 시작")
@@ -140,16 +141,3 @@ def get_stats_src_data_info(ext_api_id, stat_tbl_id_list):
         session.close()
 
 
-def insert_data_to_db(data_path, meta_path, stats_src):
-    db_logger.info(f"DB Insert Start: {stats_src.get('stat_tbl_id')}")
-    try:
-        # 파일을 읽어 실제 데이터 테이블에 삽입
-        # 예시: 쿼리 실행 로그
-        db_logger.debug(f"Reading data from {data_path}, meta from {meta_path}")
-        # ... SQL 실행 예시 ...
-        # db_logger.info(f"Executing SQL: {sql} Params: {params}")
-        # db_logger.info(f"Rows affected: {rowcount}")
-        db_logger.info(f"DB Insert Success: {stats_src.get('stat_tbl_id')}")
-    except Exception as e:
-        db_logger.error(f"DB Insert Error: {stats_src.get('stat_tbl_id')} - {e}")
-        raise

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import sys
 import json
 from datetime import datetime, date
 from file_utils import save_data_and_meta_files, save_meta_file, save_latest_file, save_data_file
-from db import get_db_url, get_api_info, get_stats_src_api_info, insert_data_to_db, get_stats_src_data_info
+from db import get_db_url, get_api_info, get_stats_src_api_info, get_stats_src_data_info
 from kosis_api import fetch_kosis_data, fetch_kosis_meta, fetch_kosis_latest
 from config import load_target_src_tbl_id_list, get_log_level, get_data_collection_scope, get_parallel_workers_file
 from db_processing import process_db_insertion


### PR DESCRIPTION
## 변경 내용

### db.py
- `engine = create_engine(DB_URL) if DB_URL else None` — DB_URL 없을 때 임포트 단계에서 비정상 종료 방지
- `Session = sessionmaker(bind=engine) if engine else None`
- `event.listen` 블록을 `if engine:` 조건 하에 실행
- `insert_data_to_db()` 미구현 stub 함수 삭제

### main.py
- import 구문에서 `insert_data_to_db` 제거

## 검증
- `python3 -m py_compile db.py` 통과
- `python3 -m py_compile main.py` 통과

Closes #17
Closes #18