### PR TITLE
v1.1.1 - db_processing: latest 파일 JSON/XML 형식 분기 파싱 수정

### DIFF
--- a/db_processing.py
+++ b/db_processing.py
@@ -93,12 +93,28 @@ def process_single_statistic(session, file_info, api_info, stats_src, stats_data
 
 def _parse_latest_file_for_latest_date(latest_path):
     """
-    latest xml 파일에서 SendDe 중 가장 최신 날짜(YYYY-MM-DD)를 추출
+    latest 파일에서 SendDe 중 가장 최신 날짜(YYYY-MM-DD)를 추출.
+    파일 확장자(.json / .xml)에 따라 적절한 파서를 사용한다.
     """
-    tree = ET.parse(latest_path)
-    root = tree.getroot()
-    send_de_list = [row.findtext('SendDe') for row in root.findall('.//MetaRow') if row.findtext('SendDe')]
-    # YYYY-MM-DD 형식으로 변환 (예: 2024-12-30)
+    send_de_list = []
+    if latest_path.endswith('.json'):
+        with open(latest_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict):
+                    val = item.get('SendDe')
+                    if val:
+                        send_de_list.append(val)
+        elif isinstance(data, dict):
+            val = data.get('SendDe')
+            if val:
+                send_de_list.append(val)
+    else:
+        tree = ET.parse(latest_path)
+        root = tree.getroot()
+        send_de_list = [row.findtext('SendDe') for row in root.findall('.//MetaRow') if row.findtext('SendDe')]
+    # YYYY-MM-DD 형식 (예: 2024-12-30)
     send_de_list = [d for d in send_de_list if d]
     if not send_de_list:
         return None


### PR DESCRIPTION
## 변경 내용

Closes #52

### 수정 파일
- `db_processing.py`: `_parse_latest_file_for_latest_date` 함수 수정

### 수정 내용
- 기존: 항상 `ET.parse()`(XML)만 시도 → JSON 형식 latest 파일 처리 불가
- 수정: 파일 확장자(`.json` / `.xml`)를 확인하고 각 형식에 맞게 파싱
  - `.json`: `json.load()` 후 list/dict 구조에서 `SendDe` 추출
  - 그 외: 기존 XML 파싱 로직 유지
- `import json`은 이미 파일 상단에 있어 추가 import 불필요

### 테스트 방법
1. `.env` 에 `LATEST_FORMAT=json` 설정
2. `python main.py --mode db` 실행
3. JSON 형식의 latest 파일이 정상적으로 파싱되어 최신 날짜를 반환하는지 확인

### 참고
- 버전: v1.1.1 (patch bump from v1.1.0)
- `.claude/config.md` (워크스페이스 로컬 메타파일)은 GitHub에 푸시되지 않으므로 PR에서 제외