### PR TITLE
v1.1.2 - kosis_api: sys.exit RuntimeError 교체, while if 무한루프 방지

### DIFF
--- a/kosis_api.py
+++ b/kosis_api.py
@@ -50,11 +50,11 @@ def fetch_kosis_data_single(api_info, stats_src, stats_src_data_info, from_year,
         if response.status_code != 200:
             logging.error(f'KOSIS data API 요청 실패: status={response.status_code}, url={url}, response={response.text[:200]}')
             print(f"[ERROR] KOSIS data API 요청 실패: status={response.status_code}, url={url}")
-            import sys; sys.exit(1)
+            raise RuntimeError("KOSIS API 요청 실패")
     except Exception as e:
         logging.error(f'KOSIS data API 요청 중 예외 발생: {e}', exc_info=True)
         print(f"[ERROR] KOSIS data API 요청 중 예외 발생: {e}")
-        import sys; sys.exit(1)
+        raise RuntimeError("KOSIS API 처리 중단")
     
     if file_format == 'json':
         return response.json()
@@ -69,7 +69,7 @@ def fetch_kosis_data_split(api_info, stats_src, stats_src_data_info, from_year, 
     all_data = []
     year_gap = to_year - from_year + 1
     
-    while year_gap > 1:  # 1년 초과 시에만 분할
+    if year_gap > 1:  # 1년 초과 시에만 분할
         mid_year = from_year + (year_gap // 2)
         
         # 전반부 수집
@@ -101,7 +101,7 @@ def fetch_kosis_data_split(api_info, stats_src, stats_src_data_info, from_year, 
     if is_error_31(response):
         logging.error(f"Error 31: 1년 단위({from_year}~{to_year})에서도 데이터 수집 실패")
         print(f"[ERROR] KOSIS API Error 31: 1년 단위({from_year}~{to_year})에서도 데이터 수집 실패")
-        import sys; sys.exit(1)
+        raise RuntimeError("KOSIS API 처리 중단")
     
     return response if isinstance(response, list) else [response]
 
@@ -132,11 +132,11 @@ def fetch_kosis_meta(api_info, stats_src, stats_src_data_info):
         if response.status_code != 200:
             logging.error(f'KOSIS meta API 요청 실패: status={response.status_code}, url={url}, response={response.text[:200]}')
             print(f"[ERROR] KOSIS meta API 요청 실패: status={response.status_code}, url={url}")
-            import sys; sys.exit(1)
+            raise RuntimeError("KOSIS API 요청 실패")
     except Exception as e:
         logging.error(f'KOSIS meta API 요청 중 예외 발생: {e}', exc_info=True)
         print(f"[ERROR] KOSIS meta API 요청 중 예외 발생: {e}")
-        import sys; sys.exit(1)
+        raise RuntimeError("KOSIS API 처리 중단")
     if file_format == 'json':
         return response.json()
     else:
@@ -152,11 +152,11 @@ def fetch_kosis_latest(api_info, stats_src, stats_src_data_info):
         if response.status_code != 200:
             logging.error(f'KOSIS latest API 요청 실패: status={response.status_code}, url={url}, response={response.text[:200]}')
             print(f"[ERROR] KOSIS latest API 요청 실패: status={response.status_code}, url={url}")
-            import sys; sys.exit(1)
+            raise RuntimeError("KOSIS API 요청 실패")
     except Exception as e:
         logging.error(f'KOSIS latest API 요청 중 예외 발생: {e}', exc_info=True)
         print(f"[ERROR] KOSIS latest API 요청 중 예외 발생: {e}")
-        import sys; sys.exit(1)
+        raise RuntimeError("KOSIS API 처리 중단")
     if file_format == 'json':
         return response.json()
     else:

--- a/main.py
+++ b/main.py
@@ -160,7 +160,7 @@ def save_single_file(args):
         }
     except Exception as e:
         logging.error(f"[{stat_tbl_id}] {func_name} - 파일 저장 중 에러: {e}", exc_info=True)
-        import sys; sys.exit(1)
+        raise RuntimeError(f"[{stat_tbl_id}] {func_name} - 파일 저장 실패") from e
 
 def save_all_files(api_info, stats_src_list, dirs, stats_src_data_info_dict):
     saved_files_info = []


### PR DESCRIPTION
## 변경 내용

Closes #31
Closes #32

### 수정 파일
- `kosis_api.py`: 7곳의 `sys.exit(1)` → `raise RuntimeError(...)` 교체, `while year_gap > 1` → `if year_gap > 1`
- `main.py`: `save_single_file` 내 (ThreadPoolExecutor 호출) `sys.exit(1)` → `raise RuntimeError(...) from e`

### 수정 내용 - Item #5 (Issue #31)
- 문제: ThreadPoolExecutor 워커 함수에서 `sys.exit(1)` 호출 시 전체 프로세스 강제 종료 → 다른 스레드의 자원 정리 방해
- 해결: `raise RuntimeError(...)` 로 교체 → `Future.result()` 가 정상적으로 예외를 포착, 스레드별 정리 가능
- `main.py`의 CLI 시작 검증/최외곽 예외 핸들러의 `sys.exit(1)`은 의도된 동작이라 보존 (Thread Pool 컨텍스트가 아님)

### 수정 내용 - Item #6 (Issue #32)
- 문제: `while year_gap > 1:` 루프가 사실상 `if` 처럼 동작 (재귀 호출이 분할을 처리). 이론상 동일 조건 반복 시 무한루프 가능
- 해결: `if year_gap > 1:` 로 변경 → 한 번만 분할 시도하고 재귀 호출이 추가 분할 처리. 의도와 코드가 일치하도록 명시화

### 테스트 방법
- `python3 -m py_compile kosis_api.py main.py` → 모두 OK
- `grep` 으로 `sys.exit` / `while year_gap` 잔존 확인 → 모두 정리됨