### PR TITLE
v1.3.0 - 이슈 #27 db.py get_api_info() 멀티소스 동적 조회 지원

### DIFF
--- a/db.py
+++ b/db.py
@@ -51,6 +51,10 @@ def get_api_info(ext_sys: str = 'KOSIS'):
         >>> info = get_api_info()                  # 기존 KOSIS 호출 (후방호환)
         >>> info = get_api_info('KOSIS')           # 명시 호출
         >>> info = get_api_info('DATA_GO_KR')      # 신규 소스
+
+    설계 근거:
+        docs/design/26-multi-source-architecture.md §3.3.1
+        (이슈 #26 — 멀티 외부 API 소스 확장 아키텍처)
     """
     db_logger.info(f"외부 API 정보 조회 시작 (ext_sys={ext_sys})")
     try:

--- a/db.py
+++ b/db.py
@@ -29,7 +29,7 @@ if engine:
         db_logger.error(f"DB 타임존 설정 실패: {e}")
 
 def get_api_info(ext_sys: str = 'KOSIS'):
-    db_logger.info("KOSIS API 정보 조회 시작")
+    db_logger.info(f"외부 API 정보 조회 시작 (ext_sys={ext_sys})")
     try:
         session = Session()
         query = text("""
@@ -39,7 +39,7 @@ def get_api_info(ext_sys: str = 'KOSIS'):
             WHERE ext_sys = :ext_sys AND del_yn = 'N' AND status = 'A'
         """)
         db_logger.debug(f"Executing SQL: {query}")
-        result = session.execute(query, {'ext_sys': EXT_SYS_KOSIS})
+        result = session.execute(query, {'ext_sys': ext_sys})
         row = result.fetchone()
         
         if row:
@@ -53,14 +53,14 @@ def get_api_info(ext_sys: str = 'KOSIS'):
                 'latest_sync_time': row.latest_sync_time,
                 'status': row.status
             }
-            db_logger.info(f"KOSIS API 정보 조회 성공: {api_info['ext_sys']} - {api_info['if_name']} - {api_info['status']}")
+            db_logger.info(f"외부 API 정보 조회 성공: {api_info['ext_sys']} - {api_info['if_name']} - {api_info['status']}")
             return api_info
         else:
-            db_logger.warning("KOSIS API 정보가 DB에 없거나 삭제된 상태입니다.")
+            db_logger.warning(f"외부 API 정보가 DB에 없거나 삭제된 상태입니다 (ext_sys={ext_sys}).")
             return {}
             
     except Exception as e:
-        db_logger.error(f"KOSIS API 정보 조회 실패: {e}")
+        db_logger.error(f"외부 API 정보 조회 실패 (ext_sys={ext_sys}): {e}")
         raise
     finally:
         session.close()

--- a/db.py
+++ b/db.py
@@ -29,6 +29,29 @@ if engine:
         db_logger.error(f"DB 타임존 설정 실패: {e}")
 
 def get_api_info(ext_sys: str = 'KOSIS'):
+    """sys_ext_api_info 테이블에서 ext_sys 키로 외부 API 메타데이터를 단건 조회한다.
+
+    이슈 #27 — 멀티소스 동적 조회 지원.
+    `sys_ext_api_info.ext_sys` 컬럼을 라우팅 키로 사용하여 KOSIS 이외의 신규
+    외부 API 소스도 동일한 인터페이스로 조회할 수 있도록 일반화했다.
+
+    Args:
+        ext_sys: 조회할 외부 시스템 식별자.
+            - 'KOSIS' (default): 국가통계포털 (후방호환 — 인자 미지정 시)
+            - 'DATA_GO_KR': 공공데이터포털 (예시)
+            - 'MICRODATA': 마이크로데이터 (예시)
+            기타 sys_ext_api_info 에 등록된 임의 ext_sys 값.
+
+    Returns:
+        단건 dict — 컬럼: ext_api_id / if_name / ext_sys / ext_url / auth /
+        data_format / latest_sync_time / status.
+        해당 ext_sys 의 active 행이 없으면 빈 dict ({}) 반환.
+
+    예시:
+        >>> info = get_api_info()                  # 기존 KOSIS 호출 (후방호환)
+        >>> info = get_api_info('KOSIS')           # 명시 호출
+        >>> info = get_api_info('DATA_GO_KR')      # 신규 소스
+    """
     db_logger.info(f"외부 API 정보 조회 시작 (ext_sys={ext_sys})")
     try:
         session = Session()

--- a/db.py
+++ b/db.py
@@ -28,7 +28,7 @@ if engine:
     except Exception as e:
         db_logger.error(f"DB 타임존 설정 실패: {e}")
 
-def get_api_info():
+def get_api_info(ext_sys: str = 'KOSIS'):
     db_logger.info("KOSIS API 정보 조회 시작")
     try:
         session = Session()

--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ def check_required_env_and_args(args):
         sys.exit(1)
 
 def get_filtered_stats_src_list(data_collection_scope):
+    # default ext_sys='KOSIS' 사용 (이슈 #27 후방호환 — 인자 미지정 시 KOSIS 경로)
     api_info = get_api_info()
     stats_src_list = get_stats_src_api_info(api_info.get('ext_api_id'))
     env_target_list = None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for db.get_api_info()
+
+이슈 #27 — 멀티소스 동적 조회 지원
+- KOSIS path (default ext_sys='KOSIS'): 후방호환 검증
+- non-KOSIS path: 신규 분기 동작 검증
+
+DB 접속 없이 mock 으로 SQL 바인딩 파라미터·반환값 형태만 검증한다.
+"""
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+# 테스트 실행을 위한 환경: 모듈 import 시 외부 DB 접속을 시도하지 않도록
+# config.py / dotenv 가 로컬 .env 없이도 안전하게 동작함을 가정한다.
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+class _FakeRow:
+    """SQLAlchemy Row 의 속성 접근 모사"""
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class GetApiInfoKosisPathTests(unittest.TestCase):
+    """KOSIS 경로 — default 인자 호출 시 기존 동작 그대로"""
+
+    def _stub_module(self, fake_row):
+        import db as _db
+        fake_session = MagicMock()
+        fake_result = MagicMock()
+        fake_result.fetchone.return_value = fake_row
+        fake_session.execute.return_value = fake_result
+        _db.Session = MagicMock(return_value=fake_session)
+        return _db, fake_session
+
+    def test_kosis_default_call_returns_dict(self):
+        row = _FakeRow(
+            ext_api_id='KOSIS_001', if_name='KOSIS', ext_sys='KOSIS',
+            ext_url='https://kosis.kr', auth='KEY', data_format='JSON',
+            latest_sync_time=None, status='A',
+        )
+        db_mod, fake_session = self._stub_module(row)
+        out = db_mod.get_api_info()
+        self.assertIsInstance(out, dict)
+        self.assertEqual(out['ext_sys'], 'KOSIS')
+        self.assertEqual(out['ext_api_id'], 'KOSIS_001')
+
+    def test_kosis_default_binds_kosis_param(self):
+        """SQL 바인딩 dict 에 ext_sys='KOSIS' 가 들어가야 한다 (default)"""
+        row = _FakeRow(
+            ext_api_id='KOSIS_001', if_name='KOSIS', ext_sys='KOSIS',
+            ext_url='https://kosis.kr', auth='K', data_format='JSON',
+            latest_sync_time=None, status='A',
+        )
+        db_mod, fake_session = self._stub_module(row)
+        db_mod.get_api_info()
+        args, kwargs = fake_session.execute.call_args
+        self.assertEqual(args[1], {'ext_sys': 'KOSIS'})
+
+    def test_kosis_empty_db_returns_empty_dict(self):
+        db_mod, _ = self._stub_module(None)
+        out = db_mod.get_api_info()
+        self.assertEqual(out, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -69,5 +69,52 @@ class GetApiInfoKosisPathTests(unittest.TestCase):
         self.assertEqual(out, {})
 
 
+
+
+class GetApiInfoNonKosisPathTests(unittest.TestCase):
+    """non-KOSIS 경로 — ext_sys 명시 호출 시 신규 분기"""
+
+    def _stub_module(self, fake_row):
+        import db as _db
+        fake_session = MagicMock()
+        fake_result = MagicMock()
+        fake_result.fetchone.return_value = fake_row
+        fake_session.execute.return_value = fake_result
+        _db.Session = MagicMock(return_value=fake_session)
+        return _db, fake_session
+
+    def test_non_kosis_param_binds_correctly(self):
+        """ext_sys='DATA_GO_KR' 호출 시 SQL 바인딩에도 동일 값"""
+        row = _FakeRow(
+            ext_api_id='DGK_001', if_name='DataGoKr', ext_sys='DATA_GO_KR',
+            ext_url='https://api.data.go.kr', auth='KEY', data_format='JSON',
+            latest_sync_time=None, status='A',
+        )
+        db_mod, fake_session = self._stub_module(row)
+        out = db_mod.get_api_info(ext_sys='DATA_GO_KR')
+        args, kwargs = fake_session.execute.call_args
+        self.assertEqual(args[1], {'ext_sys': 'DATA_GO_KR'})
+        self.assertEqual(out['ext_sys'], 'DATA_GO_KR')
+        self.assertEqual(out['ext_api_id'], 'DGK_001')
+
+    def test_non_kosis_positional_arg(self):
+        """positional 인자도 동일하게 동작"""
+        row = _FakeRow(
+            ext_api_id='MD_001', if_name='Microdata', ext_sys='MICRODATA',
+            ext_url='https://md.kr', auth='K', data_format='CSV',
+            latest_sync_time=None, status='A',
+        )
+        db_mod, fake_session = self._stub_module(row)
+        out = db_mod.get_api_info('MICRODATA')
+        args, kwargs = fake_session.execute.call_args
+        self.assertEqual(args[1], {'ext_sys': 'MICRODATA'})
+        self.assertEqual(out['ext_sys'], 'MICRODATA')
+
+    def test_non_kosis_empty_returns_empty_dict(self):
+        db_mod, _ = self._stub_module(None)
+        out = db_mod.get_api_info(ext_sys='DATA_GO_KR')
+        self.assertEqual(out, {})
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 개요

이슈 #27 — db.py 의 `get_api_info()` 함수에 `ext_sys` 파라미터를 추가하여
KOSIS 단일 소스 의존을 풀고 멀티 외부 API 소스 동적 조회를 지원한다.

## 변경 내용

- `get_api_info(ext_sys: str = 'KOSIS')` — 시그니처 확장 (default 'KOSIS')
- SQL 바인딩 파라미터를 모듈 상수에서 함수 인자로 분기
- 로그 메시지에 `ext_sys` 컨텍스트 노출 (KOSIS 고정 표기 제거)
- docstring + 사용 예 추가, 설계 문서 cross-reference

## 후방호환

기본값 `ext_sys='KOSIS'` 이므로 기존 호출부는 변경 없이 동작.

- 운영 코드 호출부: `main.py:77 api_info = get_api_info()` — 1건 (인자 미지정)
- 변경 후에도 동일하게 KOSIS 경로 사용

## 테스트

신규 `tests/test_db.py` — 6 케이스 unittest 모두 통과.

- KOSIS path (default) — 3 케이스: dict 반환 형태 / SQL 바인딩 `{'ext_sys': 'KOSIS'}` / 빈 결과 처리
- non-KOSIS path — 3 케이스: `DATA_GO_KR` 키워드 인자 / `MICRODATA` positional 인자 / 빈 결과 처리

검증 명령:

```
python3 -m py_compile db.py tests/test_db.py
python3 -m unittest tests.test_db -v
```

## 설계 근거

`docs/design/26-multi-source-architecture.md` §3.3.1 (이슈 #26 결과물)

## 변경 파일

- `db.py` — 시그니처/로그/docstring 확장
- `main.py` — 호출부 1줄 주석 (후방호환 의도 명시)
- `tests/test_db.py` — 신규 (6 케이스)

Closes #27