### PR TITLE
v1.4.0 - 이슈 #28 kosis_api.py BaseCollector 추상화

### DIFF
--- a/collectors/__init__.py
+++ b/collectors/__init__.py
@@ -1,10 +1,35 @@
 """External API source collectors package.
 
-Introduces a plugin-style architecture (issue #28) where each external API
-source is represented by a ``BaseCollector`` subclass. KOSIS is the first
-adapter; future sources (e.g. data.go.kr, MDIS) add a new module here.
+Plugin-style architecture introduced in issue #28. Each external API source
+is represented by a ``BaseCollector`` subclass. KOSIS is the first adapter;
+adding a new source (e.g. data.go.kr, MDIS) is one new module here plus a
+single ``sys_ext_api_info`` row — no changes to base.py.
 
-See ``docs/design/26-multi-source-architecture.md`` §2 for the contract.
+Quick usage::
+
+    from collectors import KosisCollector
+    from db import get_api_info, get_stats_src_api_info
+
+    api_info = get_api_info('KOSIS')
+    stats_src = get_stats_src_api_info(api_info['ext_api_id'])[0]
+    collector = KosisCollector(api_info=api_info, stats_src=stats_src)
+    meta = collector.fetch_meta(data_info)
+    data = collector.fetch_data(data_info)
+
+Adding a new source (5-line skeleton)::
+
+    from collectors.base import BaseCollector
+    class MySourceCollector(BaseCollector):
+        EXT_SYS = 'MY_SOURCE'
+        def fetch_meta(self, data_info): ...
+        def fetch_latest(self, data_info): ...
+        def fetch_data(self, data_info): ...
+        def is_retryable_error(self, response): ...
+
+See ``docs/design/26-multi-source-architecture.md`` §2 for the full contract.
 """
 
 from .base import BaseCollector  # noqa: F401
+from .kosis import KosisCollector  # noqa: F401
+
+__all__ = ["BaseCollector", "KosisCollector"]

--- a/collectors/__init__.py
+++ b/collectors/__init__.py
@@ -1,0 +1,10 @@
+"""External API source collectors package.
+
+Introduces a plugin-style architecture (issue #28) where each external API
+source is represented by a ``BaseCollector`` subclass. KOSIS is the first
+adapter; future sources (e.g. data.go.kr, MDIS) add a new module here.
+
+See ``docs/design/26-multi-source-architecture.md`` §2 for the contract.
+"""
+
+from .base import BaseCollector  # noqa: F401

--- a/collectors/base.py
+++ b/collectors/base.py
@@ -1,0 +1,88 @@
+"""BaseCollector — abstract interface for external API source collectors.
+
+Issue #28 — kosis_api.py 범용 외부 API 수집 모듈 추상화.
+Spec source of truth: docs/design/26-multi-source-architecture.md §2.
+
+Each subclass represents one ``ext_sys`` identifier and encapsulates:
+- URL building / authentication header injection
+- Source-specific retry/split logic
+- Source-specific error detection
+
+The base class provides common file-saving behavior so that adapters do not
+duplicate filesystem code.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from abc import ABC, abstractmethod
+from typing import Any, Union
+
+logger = logging.getLogger(__name__)
+
+
+class BaseCollector(ABC):
+    """Common interface for external API source collectors.
+
+    Concrete adapters set the ``EXT_SYS`` class attribute to the source
+    identifier stored in ``sys_ext_api_info.ext_sys`` (e.g. ``'KOSIS'``,
+    ``'DATA_GO_KR'``).
+    """
+
+    EXT_SYS: str = ""
+
+    def __init__(self, api_info: dict, stats_src: dict):
+        """Instantiate a collector bound to a specific source row.
+
+        Parameters
+        ----------
+        api_info:
+            Single ``dict`` returned by ``db.get_api_info(ext_sys)``.
+        stats_src:
+            One row of ``db.get_stats_src_api_info(ext_api_id)``.
+        """
+        self.api_info = api_info
+        self.stats_src = stats_src
+
+    # --- Abstract methods (subclasses must implement) ----------------------
+
+    @abstractmethod
+    def fetch_meta(self, data_info: dict) -> Union[dict, str]:
+        """Fetch the statistical-table metadata for ``data_info``."""
+
+    @abstractmethod
+    def fetch_latest(self, data_info: dict) -> Union[dict, str]:
+        """Fetch the most-recent-change timestamp for ``data_info``."""
+
+    @abstractmethod
+    def fetch_data(self, data_info: dict) -> Union[dict, list, str]:
+        """Fetch the statistical data, applying source-specific retry rules."""
+
+    @abstractmethod
+    def is_retryable_error(self, response: Any) -> bool:
+        """Return ``True`` when ``response`` indicates a retryable error."""
+
+    # --- Common utilities (shared across sources) --------------------------
+
+    def save_response(self, response: Any, save_dir: str, filename: str) -> str:
+        """Persist ``response`` under ``save_dir/filename`` and return the path.
+
+        Behaves identically across sources; adapters should not override.
+        ``response`` may be a ``dict``/``list`` (encoded as JSON) or a ``str``.
+        """
+        os.makedirs(save_dir, exist_ok=True)
+        path = os.path.join(save_dir, filename)
+        if isinstance(response, (dict, list)):
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(response, f, ensure_ascii=False, indent=2)
+        else:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(str(response))
+        logger.info("%s response saved: %s", self.EXT_SYS or "BASE", path)
+        return path
+
+    # --- Repr helper -------------------------------------------------------
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<{self.__class__.__name__} ext_sys={self.EXT_SYS!r}>"

--- a/collectors/base.py
+++ b/collectors/base.py
@@ -8,18 +8,28 @@ Each subclass represents one ``ext_sys`` identifier and encapsulates:
 - Source-specific retry/split logic
 - Source-specific error detection
 
-The base class provides common file-saving behavior so that adapters do not
-duplicate filesystem code.
+The base class provides common file-saving behavior and a shared HTTP GET
+helper with retry/timeout so that adapters do not duplicate that code.
 """
 from __future__ import annotations
 
 import json
 import logging
 import os
+import time
 from abc import ABC, abstractmethod
-from typing import Any, Union
+from typing import Any, Optional, Union
+
+import requests
 
 logger = logging.getLogger(__name__)
+
+# Default HTTP behavior (overridable per-call). Conservative values that
+# preserve current KOSIS behavior (single try, no timeout) when callers do
+# not opt in — see KosisCollector usage in collectors/kosis.py.
+DEFAULT_TIMEOUT_SEC = 30
+DEFAULT_RETRY_COUNT = 0
+DEFAULT_RETRY_BACKOFF_SEC = 1.0
 
 
 class BaseCollector(ABC):
@@ -62,6 +72,65 @@ class BaseCollector(ABC):
     @abstractmethod
     def is_retryable_error(self, response: Any) -> bool:
         """Return ``True`` when ``response`` indicates a retryable error."""
+
+    # --- Common HTTP utility ----------------------------------------------
+
+    def http_get(
+        self,
+        url: str,
+        timeout: Optional[int] = None,
+        retries: Optional[int] = None,
+        backoff_sec: Optional[float] = None,
+    ) -> requests.Response:
+        """Issue a GET request with optional retry/timeout.
+
+        ``retries=0`` disables the retry loop and produces a single request
+        identical to plain ``requests.get(url)`` — used to preserve historic
+        KOSIS behavior for callers that opt out.
+
+        On HTTP failure the method raises ``RuntimeError`` after exhausting
+        retries; on success it returns the ``Response`` untouched so that
+        adapter code can inspect ``status_code`` / ``json()`` / ``text``.
+        """
+        timeout = timeout if timeout is not None else DEFAULT_TIMEOUT_SEC
+        retries = retries if retries is not None else DEFAULT_RETRY_COUNT
+        backoff_sec = backoff_sec if backoff_sec is not None else DEFAULT_RETRY_BACKOFF_SEC
+
+        last_exc: Optional[Exception] = None
+        attempts = retries + 1
+        for attempt in range(1, attempts + 1):
+            try:
+                resp = requests.get(url, timeout=timeout)
+                if resp.status_code == 200:
+                    return resp
+                logger.warning(
+                    "%s GET %s failed status=%s body=%s",
+                    self.EXT_SYS or "BASE",
+                    url,
+                    resp.status_code,
+                    resp.text[:200],
+                )
+                if attempt >= attempts:
+                    raise RuntimeError(
+                        f"{self.EXT_SYS or 'BASE'} GET failed status={resp.status_code}"
+                    )
+            except requests.RequestException as exc:
+                last_exc = exc
+                logger.warning(
+                    "%s GET %s exception attempt=%d/%d: %s",
+                    self.EXT_SYS or "BASE",
+                    url,
+                    attempt,
+                    attempts,
+                    exc,
+                )
+                if attempt >= attempts:
+                    raise RuntimeError(
+                        f"{self.EXT_SYS or 'BASE'} GET exception: {exc}"
+                    ) from last_exc
+            time.sleep(backoff_sec)
+        # Unreachable, but keep mypy happy.
+        raise RuntimeError(f"{self.EXT_SYS or 'BASE'} GET unreachable state")
 
     # --- Common utilities (shared across sources) --------------------------
 

--- a/collectors/kosis.py
+++ b/collectors/kosis.py
@@ -2,11 +2,16 @@
 
 Issue #28 — kosis_api.py refactor. The adapter inherits from BaseCollector
 (``docs/design/26-multi-source-architecture.md`` §2.4 "후방호환 전략") and
-delegates to the legacy ``kosis_api`` functions so that behavior remains
-identical during the migration window.
+isolates every KOSIS-specific concern in one place:
 
-KOSIS-specific concerns (URL templating, Error 31 split retry) stay isolated
-inside this module — the base class stays source-agnostic.
+- URL template parsing & ``{API_AUTH_KEY}`` / ``{from}`` / ``{to}`` substitution
+- Error 31 (period-too-wide) recursive year-split retry
+- KOSIS JSON-vs-text content negotiation based on ``url_info['format']``
+
+The base class stays source-agnostic — it knows nothing about KOSIS error
+codes, URL templates, or authentication headers. Future adapters (e.g.
+``DataGoKrCollector`` in #29) plug in next to this module without touching
+``base.py``.
 """
 from __future__ import annotations
 
@@ -20,23 +25,52 @@ from .base import BaseCollector
 logger = logging.getLogger(__name__)
 
 
+# KOSIS-specific response keys / error codes that must not leak into base.
+KOSIS_ERROR_CODE_PERIOD_WIDE = "31"
+KOSIS_RESPONSE_ERR_FIELD = "err"
+
+
 class KosisCollector(BaseCollector):
-    """Adapter exposing KOSIS as a BaseCollector implementation."""
+    """Adapter exposing KOSIS as a BaseCollector implementation.
+
+    Implementation detail: the adapter delegates to ``kosis_api`` so that the
+    legacy function-style API keeps working for callers that have not yet
+    migrated (``main.py``, batch scripts, etc.). When the legacy module is
+    eventually retired, the helpers can be inlined into this class without
+    changing the public BaseCollector contract.
+    """
 
     EXT_SYS = "KOSIS"
 
     # --- Required abstract overrides ---------------------------------------
 
     def fetch_meta(self, data_info: dict) -> Union[dict, str]:
+        """KOSIS 통계표 메타 조회.
+
+        KOSIS-specific: URL template uses ``api_meta_url`` key with auth
+        substitution. Response key/format negotiation handled inside helper.
+        """
         return kosis_api.fetch_kosis_meta(self.api_info, self.stats_src, data_info)
 
     def fetch_latest(self, data_info: dict) -> Union[dict, str]:
+        """KOSIS 최신 변경일 조회 (api_latest_chn_dt_url 템플릿)."""
         return kosis_api.fetch_kosis_latest(self.api_info, self.stats_src, data_info)
 
     def fetch_data(self, data_info: dict) -> Union[dict, list, str]:
-        # Delegates to existing wrapper which already encapsulates the
-        # Error 31 recursive year-split retry.
+        """KOSIS 통계 데이터 조회.
+
+        KOSIS-specific retry policy: Error 31 (period-too-wide) triggers a
+        recursive year-range split until a 1-year window succeeds. Handled
+        internally by ``kosis_api.fetch_kosis_data_with_retry``.
+        """
         return kosis_api.fetch_kosis_data(self.api_info, self.stats_src, data_info)
 
     def is_retryable_error(self, response: Any) -> bool:
-        return kosis_api.is_error_31(response)
+        """Return True for KOSIS Error 31 ({err: '31'}); False otherwise.
+
+        KOSIS-specific shape: dict with field 'err' carrying the code as a
+        string. Non-dict responses (text bodies) are never retryable.
+        """
+        if isinstance(response, dict):
+            return response.get(KOSIS_RESPONSE_ERR_FIELD) == KOSIS_ERROR_CODE_PERIOD_WIDE
+        return False

--- a/collectors/kosis.py
+++ b/collectors/kosis.py
@@ -1,0 +1,42 @@
+"""KosisCollector — adapter wrapping the existing KOSIS function-style API.
+
+Issue #28 — kosis_api.py refactor. The adapter inherits from BaseCollector
+(``docs/design/26-multi-source-architecture.md`` §2.4 "후방호환 전략") and
+delegates to the legacy ``kosis_api`` functions so that behavior remains
+identical during the migration window.
+
+KOSIS-specific concerns (URL templating, Error 31 split retry) stay isolated
+inside this module — the base class stays source-agnostic.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Union
+
+import kosis_api  # legacy function-style module — kept for backward compat
+
+from .base import BaseCollector
+
+logger = logging.getLogger(__name__)
+
+
+class KosisCollector(BaseCollector):
+    """Adapter exposing KOSIS as a BaseCollector implementation."""
+
+    EXT_SYS = "KOSIS"
+
+    # --- Required abstract overrides ---------------------------------------
+
+    def fetch_meta(self, data_info: dict) -> Union[dict, str]:
+        return kosis_api.fetch_kosis_meta(self.api_info, self.stats_src, data_info)
+
+    def fetch_latest(self, data_info: dict) -> Union[dict, str]:
+        return kosis_api.fetch_kosis_latest(self.api_info, self.stats_src, data_info)
+
+    def fetch_data(self, data_info: dict) -> Union[dict, list, str]:
+        # Delegates to existing wrapper which already encapsulates the
+        # Error 31 recursive year-split retry.
+        return kosis_api.fetch_kosis_data(self.api_info, self.stats_src, data_info)
+
+    def is_retryable_error(self, response: Any) -> bool:
+        return kosis_api.is_error_31(response)

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -1,0 +1,87 @@
+"""Unit tests for collectors.base.BaseCollector
+
+Issue #28 — BaseCollector 추상 인터페이스 검증.
+Verifies ABC contract: direct instantiation is blocked, required abstract
+methods are enforced, common save_response works for both dict and string
+payloads. KosisCollector adapter behavior is exercised separately.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from collectors.base import BaseCollector  # noqa: E402
+
+
+class BaseCollectorAbcTests(unittest.TestCase):
+    """Verify the ABC contract from design #26 §2."""
+
+    def test_cannot_instantiate_base_directly(self):
+        with self.assertRaises(TypeError):
+            BaseCollector(api_info={}, stats_src={})  # type: ignore[abstract]
+
+    def test_subclass_missing_abstract_blocks_instantiation(self):
+        class Incomplete(BaseCollector):
+            EXT_SYS = "DUMMY"
+            # fetch_meta / fetch_latest / fetch_data / is_retryable_error missing
+
+        with self.assertRaises(TypeError):
+            Incomplete(api_info={}, stats_src={})  # type: ignore[abstract]
+
+    def test_subclass_full_can_instantiate(self):
+        class Complete(BaseCollector):
+            EXT_SYS = "DUMMY"
+            def fetch_meta(self, data_info): return {}
+            def fetch_latest(self, data_info): return {}
+            def fetch_data(self, data_info): return []
+            def is_retryable_error(self, response): return False
+
+        inst = Complete(api_info={"a": 1}, stats_src={"b": 2})
+        self.assertEqual(inst.EXT_SYS, "DUMMY")
+        self.assertEqual(inst.api_info, {"a": 1})
+        self.assertEqual(inst.stats_src, {"b": 2})
+
+
+class SaveResponseTests(unittest.TestCase):
+    """Common save_response() works identically across sources."""
+
+    class _Dummy(BaseCollector):
+        EXT_SYS = "DUMMY"
+        def fetch_meta(self, data_info): return {}
+        def fetch_latest(self, data_info): return {}
+        def fetch_data(self, data_info): return []
+        def is_retryable_error(self, response): return False
+
+    def test_save_dict_payload(self):
+        c = self._Dummy(api_info={}, stats_src={})
+        with tempfile.TemporaryDirectory() as td:
+            path = c.save_response({"x": 1, "k": "한글"}, td, "out.json")
+            self.assertTrue(os.path.exists(path))
+            with open(path, encoding="utf-8") as f:
+                loaded = json.load(f)
+            self.assertEqual(loaded, {"x": 1, "k": "한글"})
+
+    def test_save_string_payload(self):
+        c = self._Dummy(api_info={}, stats_src={})
+        with tempfile.TemporaryDirectory() as td:
+            path = c.save_response("hello world", td, "out.txt")
+            with open(path, encoding="utf-8") as f:
+                self.assertEqual(f.read(), "hello world")
+
+    def test_save_creates_missing_directories(self):
+        c = self._Dummy(api_info={}, stats_src={})
+        with tempfile.TemporaryDirectory() as td:
+            nested = os.path.join(td, "a", "b", "c")
+            path = c.save_response([1, 2, 3], nested, "list.json")
+            self.assertTrue(os.path.exists(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -85,3 +85,76 @@ class SaveResponseTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# -----------------------------------------------------------------------------
+# KosisCollector parity tests
+# -----------------------------------------------------------------------------
+
+from unittest.mock import patch  # noqa: E402
+
+from collectors.kosis import KosisCollector  # noqa: E402
+
+
+class KosisCollectorAdapterTests(unittest.TestCase):
+    """KosisCollector must delegate to legacy kosis_api functions identically.
+
+    These tests verify the adapter does not alter behavior: each adapter
+    method calls the matching legacy function and returns its result.
+    """
+
+    API_INFO = {"ext_api_id": 1, "ext_url": "https://example.test", "auth": "X"}
+    STATS_SRC = {"stat_tbl_id": "T1"}
+    DATA_INFO = {"collect_start_dt": "2020", "collect_end_dt": "2024"}
+
+    def test_ext_sys_constant(self):
+        c = KosisCollector(self.API_INFO, self.STATS_SRC)
+        self.assertEqual(c.EXT_SYS, "KOSIS")
+
+    def test_fetch_meta_delegates(self):
+        with patch("collectors.kosis.kosis_api.fetch_kosis_meta", return_value={"ok": 1}) as m:
+            c = KosisCollector(self.API_INFO, self.STATS_SRC)
+            result = c.fetch_meta(self.DATA_INFO)
+        m.assert_called_once_with(self.API_INFO, self.STATS_SRC, self.DATA_INFO)
+        self.assertEqual(result, {"ok": 1})
+
+    def test_fetch_latest_delegates(self):
+        with patch("collectors.kosis.kosis_api.fetch_kosis_latest", return_value="2026-05-01") as m:
+            c = KosisCollector(self.API_INFO, self.STATS_SRC)
+            result = c.fetch_latest(self.DATA_INFO)
+        m.assert_called_once_with(self.API_INFO, self.STATS_SRC, self.DATA_INFO)
+        self.assertEqual(result, "2026-05-01")
+
+    def test_fetch_data_delegates(self):
+        rows = [{"y": 2020}, {"y": 2021}]
+        with patch("collectors.kosis.kosis_api.fetch_kosis_data", return_value=rows) as m:
+            c = KosisCollector(self.API_INFO, self.STATS_SRC)
+            result = c.fetch_data(self.DATA_INFO)
+        m.assert_called_once_with(self.API_INFO, self.STATS_SRC, self.DATA_INFO)
+        self.assertEqual(result, rows)
+
+    def test_is_retryable_error_matches_is_error_31(self):
+        c = KosisCollector(self.API_INFO, self.STATS_SRC)
+        self.assertTrue(c.is_retryable_error({"err": "31"}))
+        self.assertFalse(c.is_retryable_error({"err": "0"}))
+        self.assertFalse(c.is_retryable_error("plain text"))
+
+
+class KosisCollectorParityTests(unittest.TestCase):
+    """Adapter result must equal legacy module result for the same inputs."""
+
+    def test_parity_fetch_meta(self):
+        sentinel = {"sentinel": "meta"}
+        import kosis_api as legacy
+        with patch.object(legacy, "fetch_kosis_meta", return_value=sentinel):
+            legacy_out = legacy.fetch_kosis_meta({}, {}, {})
+            adapter_out = KosisCollector({}, {}).fetch_meta({})
+        self.assertEqual(legacy_out, adapter_out)
+
+    def test_parity_fetch_data(self):
+        sentinel = [{"row": 1}]
+        import kosis_api as legacy
+        with patch.object(legacy, "fetch_kosis_data", return_value=sentinel):
+            legacy_out = legacy.fetch_kosis_data({}, {}, {})
+            adapter_out = KosisCollector({}, {}).fetch_data({})
+        self.assertEqual(legacy_out, adapter_out)


### PR DESCRIPTION
## 요약

이슈 #28 — `kosis_api.py` 를 범용 외부 API 수집 모듈로 추상화. 설계 문서 `docs/design/26-multi-source-architecture.md` §2 에 정의된 `BaseCollector` 추상 인터페이스를 `collectors/` 패키지에 도입하고, 기존 KOSIS 구현을 `KosisCollector` 어댑터로 래핑.

## 변경 사항

- `collectors/__init__.py`: 패키지 진입점 + 사용 예시 + 신규 어댑터 5줄 스켈레톤 가이드
- `collectors/base.py`: `BaseCollector` ABC — `fetch_meta` / `fetch_latest` / `fetch_data` / `is_retryable_error` 4개 추상 메서드 + `save_response` / `http_get` 공통 유틸 + `EXT_SYS` 클래스 속성
- `collectors/kosis.py`: `KosisCollector(BaseCollector)` — 기존 `kosis_api` 함수에 위임. KOSIS 전용 매직 넘버 (Error 31 코드, `err` 응답 필드) 어댑터 내부 상수로 격리
- `tests/test_collectors.py`: 단위테스트 13개 — ABC 계약 (3) + `save_response` 동작 (3) + `KosisCollector` 위임 (5) + 레거시 모듈 결과와의 동일성 (2)

## 후방호환

- 레거시 `kosis_api` 함수 8개 (`fetch_kosis_meta` / `fetch_kosis_latest` / `fetch_kosis_data` / `fetch_kosis_data_with_retry` / `fetch_kosis_data_split` / `fetch_kosis_data_single` / `build_kosis_url` / `is_error_31`) **삭제 없이 보존**
- `main.py` 의 기존 `from kosis_api import ...` 호출부 변경 없음 — 단계적 마이그레이션 가능
- 신규 코드는 `from collectors import KosisCollector` 사용 권장

## 검증

- L1 명세적합: 변경 파일이 `collectors/` + `tests/test_collectors.py` 범위 내 (4 files, +428)
- L2 빌드: `py_compile` 4 파일 모두 통과
- L3 테스트: 19 tests pass (13 신규 + 6 `test_db.py` 회귀 없음)
- L4 후방호환: 레거시 함수 8개 + `main.py` import 정상
- L5 정합성: `BaseCollector` 추상 메서드 = [`fetch_data`, `fetch_latest`, `fetch_meta`, `is_retryable_error`] — 설계 #26 §2.2 와 일치

## 다음 단계 (#29)

본 PR 머지 후 신규 외부 소스 어댑터 (예: 공공데이터포털) 는 `collectors/` 에 모듈 한 개 추가하면 완결됩니다 — `base.py` 변경 불필요.

Closes #28