### PR TITLE
v1.5.1 - 워크스페이스 메타 파일 ignore 보강

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -324,3 +324,7 @@ failed_datas/
 .env
 .env.dev
 .env.prd
+
+# Local workspace meta
+.workspace/
+WORKSPACE.md


### PR DESCRIPTION
## 변경 내용
- `.gitignore` 에 워크스페이스 메타 파일 보호 패턴 추가 (`.workspace/`, `WORKSPACE.md`)


## 테스트 방법
- `git status` 에서 `.workspace/`, `WORKSPACE.md` 가 추적 대상에 안 나오는지 확인

Closes #60