### PR TITLE
v1.6.1 - 통합테이블 이관 prd_de 빈값 CAST 실패 수정(빈 period 행 제외)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 외부 통계 API 연동 및 파일/DB 저장 툴 (KOSIS 등 멀티소스)
 
-![version](https://img.shields.io/badge/version-v1.6.0-blue)
+![version](https://img.shields.io/badge/version-v1.6.1-blue)
 
 ## 개요
 외부 통계 API(현재 KOSIS, 향후 공공데이터포털·마이크로데이터 등) 데이터를 API를 통해 수집하여, 옵션에 따라 파일로 저장하거나 파일 저장 후 DB에 삽입하는 Python 기반 툴입니다.

--- a/db_processing.py
+++ b/db_processing.py
@@ -269,6 +269,7 @@ def _transfer_to_integration_table(session, file_info, stats_src, stats_data_inf
         WHERE src_data_id = :src_data_id
           AND tbl_id = :stat_tbl_id
           AND stat_latest_chn_dt = :stat_latest_chn_dt
+          AND prd_de ~ '^[0-9]+$'   -- 빈/비숫자 period 행 제외(CAST 실패 방지)
         """
     else:
         # dt는 숫자로 변환, '-' 또는 ''일 경우 0으로 변환
@@ -290,6 +291,7 @@ def _transfer_to_integration_table(session, file_info, stats_src, stats_data_inf
         WHERE src_data_id = :src_data_id
           AND tbl_id = :stat_tbl_id
           AND stat_latest_chn_dt = :stat_latest_chn_dt
+          AND prd_de ~ '^[0-9]+$'   -- 빈/비숫자 period 행 제외(CAST 실패 방지)
         """
     session.execute(
         text(insert_sql),

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 # preserved: with ext_sys defaulting to 'KOSIS', the legacy save path and the
 # collector behavior are identical to v1.4.0.
 # ============================================================================
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 
 


### PR DESCRIPTION
## 변경 내용
- _transfer_to_integration_table 두 INSERT WHERE 절에 prd_de ~ '^[0-9]+$' 가드 추가 → 빈/비숫자 period 행 제외
- ALL 검증 런에서 DT_438001_AC016 1건 적재 실패(invalid input syntax for type integer) 해소 목적

## 테스트 방법
- py_compile 통과
- 재배포 후 ALL 수집 시 db_fail=0 (SUCCESS) 재검증 예정

Closes #68