### PR TITLE
v1.6.2 - 단건(dict) 응답 통계 적재 실패 수정: avail_cat_cols 산출 정규화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 외부 통계 API 연동 및 파일/DB 저장 툴 (KOSIS 등 멀티소스)
 
-![version](https://img.shields.io/badge/version-v1.6.1-blue)
+![version](https://img.shields.io/badge/version-v1.6.2-blue)
 
 ## 개요
 외부 통계 API(현재 KOSIS, 향후 공공데이터포털·마이크로데이터 등) 데이터를 API를 통해 수집하여, 옵션에 따라 파일로 저장하거나 파일 저장 후 DB에 삽입하는 Python 기반 툴입니다.

--- a/db_processing.py
+++ b/db_processing.py
@@ -395,9 +395,11 @@ def _update_stats_src_data_info(session, file_info, data_json, latest_date):
     updated_at = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     updated_by = 'SYS-BATCH'
     # avail_cat_cols: data_json에서 실제 값이 존재하는 c1~c4만 추출
+    # 단일 dict 응답(KOSIS 단건)도 리스트로 정규화하고, dict 아닌 요소는 건너뜀
+    rows_iter = data_json if isinstance(data_json, list) else [data_json]
     cat_cols = []
     for c in ['c1', 'c2', 'c3', 'c4']:
-        if any((row.get(c.upper()) or row.get(c)) for row in data_json):
+        if any(isinstance(row, dict) and (row.get(c.upper()) or row.get(c)) for row in rows_iter):
             cat_cols.append(c)
     avail_cat_cols = pyjson.dumps(cat_cols, ensure_ascii=False)
     update_sql = """

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 # preserved: with ext_sys defaulting to 'KOSIS', the legacy save path and the
 # collector behavior are identical to v1.4.0.
 # ============================================================================
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 
 
 


### PR DESCRIPTION
## 변경 내용
- _update_stats_src_data_info: data_json 리스트 정규화 + dict 아닌 요소 스킵 (KOSIS 단건 응답 대응)

## 검증 (ServerA, 머지 전)
- DT_438001_AC016 단건: SUCCESS, db_fail=0
- ALL 24건: db_ok=24, db_fail=0, status=SUCCESS, exit=0

Closes #70